### PR TITLE
Fix ClassRegistryInit doesn't work with ClassConstFetch AST

### DIFF
--- a/src/ClassRegistryInitExtension.php
+++ b/src/ClassRegistryInitExtension.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PHPStanCakePHP2;
 
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Name;
 use PHPStanCakePHP2\Service\SchemaService;
 use Inflector;
 use PhpParser\ConstExprEvaluator;
@@ -44,9 +46,15 @@ class ClassRegistryInitExtension implements DynamicStaticMethodReturnTypeExtensi
 
     public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
     {
-        $arg1 = $methodCall->getArgs()[0]->value;
+        $value = $methodCall->getArgs()[0]->value;
         $evaluator = new ConstExprEvaluator();
-        $arg1 = $evaluator->evaluateSilently($arg1);
+
+        if ($value instanceof ClassConstFetch && $value->class instanceof Name) {
+            $value = $value->class->toString();
+        }
+
+        $arg1 = $evaluator->evaluateSilently($value);
+
         if (! is_string($arg1)) {
             return $this->getDefaultType();
         }

--- a/src/ClassRegistryInitExtension.php
+++ b/src/ClassRegistryInitExtension.php
@@ -6,6 +6,7 @@ namespace PHPStanCakePHP2;
 
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
 use PHPStanCakePHP2\Service\SchemaService;
 use Inflector;
 use PhpParser\ConstExprEvaluator;
@@ -49,8 +50,8 @@ class ClassRegistryInitExtension implements DynamicStaticMethodReturnTypeExtensi
         $value = $methodCall->getArgs()[0]->value;
         $evaluator = new ConstExprEvaluator();
 
-        if ($value instanceof ClassConstFetch && $value->class instanceof Name) {
-            $value = $value->class->toString();
+        if ($value instanceof ClassConstFetch && $value->class instanceof Name\FullyQualified) {
+            $value = new String_($value->class->toString());
         }
 
         $arg1 = $evaluator->evaluateSilently($value);

--- a/tests/Feature/data/class_registry_init.php
+++ b/tests/Feature/data/class_registry_init.php
@@ -12,3 +12,6 @@ assertType('bool|object', $notClass);
 
 $modelWithoutClass = ClassRegistry::init('TableWithoutModel');
 assertType('Model', $modelWithoutClass);
+
+$class = ClassRegistry::init(BasicModel::class);
+assertType('BasicModel', $class);


### PR DESCRIPTION
Fix class registry to be able to work with class const fetch.

Fix failure on a case:
```php
ClassRegistry::init(MyModel::class)
```