### PR TITLE
Return Model if variable is passed into ClassRegistry::init method

### DIFF
--- a/tests/Feature/data/class_registry_init.php
+++ b/tests/Feature/data/class_registry_init.php
@@ -15,3 +15,7 @@ assertType('Model', $modelWithoutClass);
 
 $class = ClassRegistry::init(BasicModel::class);
 assertType('BasicModel', $class);
+
+$var = 'BasicModel';
+
+assertType('Model', ClassRegistry::init($var));


### PR DESCRIPTION
This PR improves `ClassRegistry::init` detection and returns a Model in case variable is passed into