### PR TITLE
Fix error occurred when not a string is passed into ClassRegistry::init method

### DIFF
--- a/tests/Feature/data/class_registry_init.php
+++ b/tests/Feature/data/class_registry_init.php
@@ -18,4 +18,6 @@ assertType('BasicModel', $class);
 
 $var = 'BasicModel';
 
-assertType('Model', ClassRegistry::init($var));
+assertType('BasicModel', ClassRegistry::init($var));
+
+assertType('bool|object', ClassRegistry::init([123]));


### PR DESCRIPTION
Fix error occurred when not a string is passed into ClassRegistry::init method