### PR TITLE
Add Router.stub and allow to accept string as $url argument

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -9,6 +9,7 @@ parameters:
     schemaPaths:
       - app/Config/Schema/*.php
   stubFiles:
+    - stubs/Routing/Router.stub
     - stubs/Utility.stub
 services:
   - class: PHPStanCakePHP2\ClassComponentsExtension

--- a/stubs/Routing/Router.stub
+++ b/stubs/Routing/Router.stub
@@ -1,0 +1,9 @@
+<?php
+
+class Router
+{
+    /**
+     * @param array|string $url
+     */
+    public static function redirect($route, $url, $options = array()) {}
+}


### PR DESCRIPTION
This PR adds Router.php stub so the second argument of `redirect` method allows to pass string.